### PR TITLE
Sanitize booking confirmation emails

### DIFF
--- a/server-sqlite.js
+++ b/server-sqlite.js
@@ -10,6 +10,16 @@ const bcrypt = require('bcryptjs');
 const nodemailer = require('nodemailer');
 require('dotenv').config();
 
+// Basic HTML escaping to prevent injection in email templates
+function escapeHtml(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -193,19 +203,25 @@ app.post('/api/book', async (req, res) => {
         // Send email (if configured)
         const transporter = createTransporter();
         if (transporter) {
+          const safeService = escapeHtml(service.replace(/-/g, ' ').toUpperCase());
+          const safeName = escapeHtml(name);
+          const safeDate = escapeHtml(date);
+          const safeTime = escapeHtml(time);
+          const safeNotes = escapeHtml(notes || 'None');
+
           const mailOptions = {
             from: process.env.EMAIL_USER,
             to: email,
             subject: 'Booking Confirmation - Payment Required',
             html: `
               <h2>Booking Confirmation</h2>
-              <p>Dear ${name},</p>
+              <p>Dear ${safeName},</p>
               <p>Your booking has been confirmed with the following details:</p>
               <ul>
-                <li><strong>Service:</strong> ${service.replace('-', ' ').toUpperCase()}</li>
-                <li><strong>Date:</strong> ${date}</li>
-                <li><strong>Time:</strong> ${time}</li>
-                <li><strong>Notes:</strong> ${notes || 'None'}</li>
+                <li><strong>Service:</strong> ${safeService}</li>
+                <li><strong>Date:</strong> ${safeDate}</li>
+                <li><strong>Time:</strong> ${safeTime}</li>
+                <li><strong>Notes:</strong> ${safeNotes}</li>
               </ul>
               <p><strong>Payment Required:</strong> 6 BHD</p>
               <p>Please complete your payment to secure your booking. We will contact you with payment instructions.</p>


### PR DESCRIPTION
## Summary
- escape user supplied fields when building booking confirmation emails
- ensure service names in emails replace all hyphens

## Testing
- `node test-server.js`
- `node test-booking.js`

------
https://chatgpt.com/codex/tasks/task_e_689b115a6df0832498f03f6e795d3fa7